### PR TITLE
Update osmosis to v4.1.0

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -42,7 +42,7 @@ jobs:
           - project: osmosis
             project_bin: osmosisd
             project_dir: .osmosisd
-            version: v3.1.0
+            version: v4.1.0
             repository: https://github.com/osmosis-labs/osmosis
             namespace: OSMOSISD
             wasmvm_version: main

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[sentinelhub](https://github.com/sentinel-official/hub)|`v0.7.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-sentinelhub-v0.7.0`|[Example](./sentinelhub)|
 |[gaia](https://github.com/cosmos/gaia)|`v4.2.1`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-gaia-v4.2.1`|[Example](./gaia)|
 |[kava](https://github.com/Kava-Labs/kava)|`v0.14.2`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-kava-v0.14.2`|[Example](./kava)|
-|[osmosis](https://github.com/osmosis-labs/osmosis)|`v3.1.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-osmosis-v3.1.0`|[Example](./osmosis)|
+|[osmosis](https://github.com/osmosis-labs/osmosis)|`v4.1.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-osmosis-v4.1.0`|[Example](./osmosis)|
 |[persistence](https://github.com/persistenceOne/persistenceCore)|`v0.1.3`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-persistence-v0.1.3`|[Example](./persistence)|
 |[juno](https://github.com/CosmosContracts/Juno)|`lucina`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-juno-lucina`|[Example](./juno)|
 |[regen](https://github.com/regen-network/regen-ledger)|`v1.0.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-regen-v1.0.0`|[Example](./regen)|

--- a/osmosis/deploy.yml
+++ b/osmosis/deploy.yml
@@ -3,10 +3,11 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-osmosis-v3.1.0
+    image: ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-osmosis-v4.1.0
     env:
       - MONIKER=my-moniker-1
       - CHAIN_URL=https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/chain.json
+      - VALIDATE_GENESIS=0 # failing currently
     expose:
       - port: 26657
         as: 80

--- a/osmosis/docker-compose.yml
+++ b/osmosis/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       args:
         PROJECT: osmosis
         PROJECT_BIN: osmosisd
-        VERSION: v3.1.0
+        VERSION: v4.1.0
         REPOSITORY: https://github.com/osmosis-labs/osmosis
         NAMESPACE: OSMOSISD
     ports:
@@ -16,6 +16,7 @@ services:
     environment:
       - MONIKER=node_1
       - CHAIN_URL=https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/chain.json
+      - VALIDATE_GENESIS=0 # failing currently
     env_file:
       - ../.env
     volumes:


### PR DESCRIPTION
Validate genesis fails with the following error:

```
Error: error validating genesis file /root/.osmosisd/config/genesis.json: failed to unmarshal epochs genesis state: unknown field "current_epoch_ended" in types.EpochInfo
```

Skipping the validation (we do this for Sentinel), booting from scratch throws the error below. Not sure if this is expected and just needs to be started from a snapshot?

```
panic: unknown field "current_epoch_ended" in types.EpochInfo
```

Resolves #23 