### PR TITLE
Update sentinelhub to v0.8.3

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,7 +21,7 @@ jobs:
           - project: sentinelhub
             project_bin: sentinelhub
             project_dir: .sentinelhub
-            version: v0.7.0
+            version: v0.8.3
             repository: https://github.com/sentinel-official/hub.git
             namespace: SENTINELHUB
             wasmvm_version: main

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |Project|Version|Image| |
 |---|---|---|---|
 |[akash](https://github.com/ovrclk/akash)|`v0.12.1`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-akash-v0.12.1`|[Example](./akash)|
-|[sentinelhub](https://github.com/sentinel-official/hub)|`v0.7.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-sentinelhub-v0.7.0`|[Example](./sentinelhub)|
+|[sentinelhub](https://github.com/sentinel-official/hub)|`v0.8.3`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-sentinelhub-v0.8.3`|[Example](./sentinelhub)|
 |[gaia](https://github.com/cosmos/gaia)|`v4.2.1`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-gaia-v4.2.1`|[Example](./gaia)|
 |[kava](https://github.com/Kava-Labs/kava)|`v0.14.2`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-kava-v0.14.2`|[Example](./kava)|
 |[osmosis](https://github.com/osmosis-labs/osmosis)|`v3.1.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-osmosis-v3.1.0`|[Example](./osmosis)|

--- a/sentinelhub/deploy.yml
+++ b/sentinelhub/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-sentinelhub-v0.7.0
+    image: ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-sentinelhub-v0.8.3
     env:
       - MONIKER=my-moniker-1
       - CHAIN_URL=https://raw.githubusercontent.com/cosmos/chain-registry/master/sentinel/chain.json

--- a/sentinelhub/docker-compose.yml
+++ b/sentinelhub/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: ../
       args:
         PROJECT: sentinelhub
-        VERSION: v0.7.0
+        VERSION: v0.8.3
         REPOSITORY: https://github.com/sentinel-official/hub.git
     ports:
       - '26656:26656'


### PR DESCRIPTION
chain-id has changed so sentinelhub now requires booting from a snapshot. Will add a URL when I source one. 

Currently fails when syncing the first block:

```
Failed to process committed block (901802:A57F8A4AE3BAF013F978930C38BF685E4720881E6B15959BEF3D647551B0051C): wrong Block.Header.AppHash.  Expected 7717E3D91014152E3799DDDD5050EAD06E8795813E75EB3CF59FCDD1B35DDE87, got 80DFFF37DB0FD218A59DA1BC23287970425FB23B56B33DF3E0F4D45C8EB85419
```

Resolves #24 