### PR TITLE
Update Juno to v1.0.0

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -56,7 +56,7 @@ jobs:
           - project: juno
             project_bin: junod
             project_dir: .juno
-            version: lucina
+            version: v1.0.0
             repository: https://github.com/CosmosContracts/Juno
             namespace: JUNOD
             wasmvm_version: v0.14.0

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[kava](https://github.com/Kava-Labs/kava)|`v0.14.2`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-kava-v0.14.2`|[Example](./kava)|
 |[osmosis](https://github.com/osmosis-labs/osmosis)|`v3.1.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-osmosis-v3.1.0`|[Example](./osmosis)|
 |[persistence](https://github.com/persistenceOne/persistenceCore)|`v0.1.3`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-persistence-v0.1.3`|[Example](./persistence)|
-|[juno](https://github.com/CosmosContracts/Juno)|`lucina`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-juno-lucina`|[Example](./juno)|
+|[juno](https://github.com/CosmosContracts/Juno)|`v1.0.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-juno-v1.0.0`|[Example](./juno)|
 |[regen](https://github.com/regen-network/regen-ledger)|`v1.0.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-regen-v1.0.0`|[Example](./regen)|
 
 ## Configuration

--- a/juno/deploy.yml
+++ b/juno/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-juno-lucina
+    image: ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-juno-v1.0.0
     env:
       - MONIKER=node_1
       - CHAIN_URL=https://raw.githubusercontent.com/nullmames/juno-on-akash/main/chain.json

--- a/juno/docker-compose.yml
+++ b/juno/docker-compose.yml
@@ -8,7 +8,7 @@ services:
         PROJECT: juno
         PROJECT_BIN: junod
         PROJECT_DIR: .juno
-        VERSION: lucina
+        VERSION: v1.0.0
         REPOSITORY: https://github.com/CosmosContracts/Juno
         NAMESPACE: JUNOD
         WASMVM_VERSION: v0.14.0


### PR DESCRIPTION
This is currently failing due to the testnet chain.json 

@nullmames we might need to source a mainnet genesis URL and some peers and seeds, ideally in the new https://github.com/cosmos/chain-registry/blob/master/juno/chain.json so everything is in one place. 

Resolves #25 