### PR TITLE
Skip genesis download if file exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,12 +108,12 @@ This can be from a specific URL, a [snapshot.json](#snapshot-backup), or from a 
 
 |Variable|Description|Default|Examples|
 |---|---|---|---|
-|`BOOTSTRAP`|Whether to bootstrap the node from the snapshot URL|`1`|`0`|
 |`SNAPSHOT_URL`|A URL to a `.tar` or `.tar.gz` file| |`http://135.181.60.250/akash/akashnet-2_2021-06-16.tar`|
 |`SNAPSHOT_JSON`|A URL to a `snapshot.json` as detailed in [Snapshot backup](#snapshot-backup)| |`https://cosmos-snapshots.s3.filebase.com/akash/snapshot.json`|
 |`SNAPSHOT_FORMAT`|The format of the snapshot file|`tar.gz`|`tar`|
 |`SNAPSHOT_BASE_URL`|A base URL to a directory containing backup files| |`http://135.181.60.250/akash`|
 |`SNAPSHOT_PATTERN`|The pattern of the file in the `BASE_URL`|`$CHAIN_ID.*$SNAPSHOT_FORMAT`|`foobar.*tar.gz`|
+|`DOWNLOAD_SNAPSHOT`|Force bootstrapping from snapshot. If unset the node will only restore a snapshot if the `data` directory is missing| |`1`|
 
 ### Snapshot backup
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Chain config can be sourced from a `chain.json` file [as seen in the Cosmos Regi
 |`METADATA_URL`|URL to a `net` repo in the same form as Akash| |`https://github.com/ovrclk/net/tree/master/mainnet`
 |`CHAIN_ID`|The cosmos chain ID| |`akashnet-2`
 |`GENESIS_URL`|URL to the genesis file in `.gz` or `.zip` format. Can be set by CHAIN_URL or METADATA_URL| |`https://raw.githubusercontent.com/ovrclk/net/master/mainnet/genesis.json`
+|`DOWNLOAD_GENESIS`|Force download of genesis file. If unset the node will only download if the genesis file is missing| |`1`|
 |`VALIDATE_GENESIS`|Set to 0 to disable validation of genesis file|`1`|`0`
 
 ### P2P

--- a/run.sh
+++ b/run.sh
@@ -5,8 +5,8 @@ set -e
 export PROJECT_HOME="/root/$PROJECT_DIR"
 export NAMESPACE="${NAMESPACE:-$(echo ${PROJECT_BIN^^})}"
 export VALIDATE_GENESIS="${VALIDATE_GENESIS:-1}"
-if [[ -z $BOOTSTRAP && ( -n $SNAPSHOT_URL || -n $SNAPSHOT_BASE_URL || -n $SNAPSHOT_JSON ) && ! -d "$PROJECT_HOME/data" ]]; then
-  export BOOTSTRAP="1"
+if [[ -z $DOWNLOAD_SNAPSHOT && ( -n $SNAPSHOT_URL || -n $SNAPSHOT_BASE_URL || -n $SNAPSHOT_JSON ) && ! -d "$PROJECT_HOME/data" ]]; then
+  export DOWNLOAD_SNAPSHOT="1"
 fi
 
 if [ -n "$METADATA_URL" ]; then
@@ -122,7 +122,7 @@ if [ -n "$KEY_PATH" ]; then
 fi
 
 # Snapshot
-if [ "$BOOTSTRAP" == "1" ]; then
+if [ "$DOWNLOAD_SNAPSHOT" == "1" ]; then
   SNAPSHOT_FORMAT="${SNAPSHOT_FORMAT:-tar.gz}"
 
   if [ -z "${SNAPSHOT_URL}" ] && [ -n "${SNAPSHOT_BASE_URL}" ]; then

--- a/run.sh
+++ b/run.sh
@@ -25,6 +25,10 @@ if [ -n "$CHAIN_JSON" ]; then
   export GENESIS_URL="${GENESIS_URL:-$(echo $CHAIN_METADATA | jq -r '.genesis.genesis_url? // .genesis')}"
 fi
 
+if [[ -z $DOWNLOAD_GENESIS && -n $GENESIS_URL && ! -f "$PROJECT_HOME/config/genesis.json" ]]; then
+  export DOWNLOAD_GENESIS="1"
+fi
+
 [ -z "$CHAIN_ID" ] && echo "CHAIN_ID not found" && exit
 
 export AWS_ACCESS_KEY_ID=$S3_KEY
@@ -145,7 +149,7 @@ if [ "$BOOTSTRAP" == "1" ]; then
 fi
 
 # Download genesis
-if [ -n "$GENESIS_URL" ]; then
+if [ "$DOWNLOAD_GENESIS" == "1" ]; then
   echo "Downloading genesis"
   curl -sfL $GENESIS_URL > genesis.json
   file genesis.json | grep -q 'gzip compressed data' && mv genesis.json genesis.json.gz && gzip -d genesis.json.gz


### PR DESCRIPTION
Add `DOWNLOAD_GENESIS` option to force. Standardise `BOOTSTRAP` variable which is the same for snapshot download to `DOWNLOAD_SNAPSHOT`