### PR TITLE
Add Stargaze v1.0.0

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -67,6 +67,13 @@ jobs:
             repository: https://github.com/regen-network/regen-ledger
             namespace: REGEN
             wasmvm_version: v0.13.0
+          - project: stargaze
+            project_bin: starsd
+            project_dir: .starsd
+            version: v1.0.0
+            repository: https://github.com/public-awesome/stargaze
+            namespace: STARSD
+            wasmvm_version: v0.14.0
     steps:
       - uses: actions/checkout@v2
       - name: build

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[persistence](https://github.com/persistenceOne/persistenceCore)|`v0.1.3`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-persistence-v0.1.3`|[Example](./persistence)|
 |[juno](https://github.com/CosmosContracts/Juno)|`lucina`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-juno-lucina`|[Example](./juno)|
 |[regen](https://github.com/regen-network/regen-ledger)|`v1.0.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-regen-v1.0.0`|[Example](./regen)|
+|[stargaze](https://github.com/public-awesome/stargaze)|`v1.0.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-stargaze-v1.0.0`|[Example](./stargaze)|
 
 ## Configuration
 
@@ -54,7 +55,7 @@ Chain config can be sourced from a `chain.json` file [as seen in the Cosmos Regi
 |`CHAIN_JSON`|URL to a `chain.json` file detailing the chain meta| |`https://github.com/cosmos/chain-registry/blob/master/akash/chain.json`
 |`METADATA_URL`|URL to a `net` repo in the same form as Akash| |`https://github.com/ovrclk/net/tree/master/mainnet`
 |`CHAIN_ID`|The cosmos chain ID| |`akashnet-2`
-|`GENESIS_URL`|URL to the genesis file in `.gz` or `.zip` format. Can be set by CHAIN_URL or METADATA_URL| |`https://raw.githubusercontent.com/ovrclk/net/master/mainnet/genesis.json`
+|`GENESIS_URL`|URL to the genesis file in `.gz`, `.tar.gz`, or `.zip` format. Can be set by CHAIN_URL or METADATA_URL| |`https://raw.githubusercontent.com/ovrclk/net/master/mainnet/genesis.json`
 |`DOWNLOAD_GENESIS`|Force download of genesis file. If unset the node will only download if the genesis file is missing| |`1`|
 |`VALIDATE_GENESIS`|Set to 0 to disable validation of genesis file|`1`|`0`
 

--- a/run.sh
+++ b/run.sh
@@ -153,6 +153,7 @@ if [ "$DOWNLOAD_GENESIS" == "1" ]; then
   echo "Downloading genesis"
   curl -sfL $GENESIS_URL > genesis.json
   file genesis.json | grep -q 'gzip compressed data' && mv genesis.json genesis.json.gz && gzip -d genesis.json.gz
+  file genesis.json | grep -q 'tar archive' && mv genesis.json genesis.json.tar && tar -xf genesis.json.tar && rm genesis.json.tar
   file genesis.json | grep -q 'Zip archive data' && mv genesis.json genesis.json.zip && unzip -o genesis.json.zip
   mv genesis.json $PROJECT_HOME/config/genesis.json
 fi

--- a/stargaze/deploy.yml
+++ b/stargaze/deploy.yml
@@ -1,0 +1,45 @@
+---
+version: "2.0"
+
+services:
+  node:
+    image: ghcr.io/ovrclk/cosmos-omnibus:v0.0.6-stargaze-v1.0.0
+    env:
+      - MONIKER=my-moniker-1
+      - CHAIN_URL=https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/chain.json
+    expose:
+      - port: 26657
+        as: 80
+        to:
+          - global: true
+      - port: 26656
+        to:
+          - global: true
+
+profiles:
+  compute:
+    node:
+      resources:
+        cpu:
+          units: 2
+        memory:
+          size: 4Gi
+        storage:
+          size: 100Gi
+  placement:
+    dcloud:
+      attributes:
+        host: akash
+      signedBy:
+        anyOf:
+          - akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63
+      pricing:
+        node:
+          denom: uakt
+          amount: 100
+
+deployment:
+  node:
+    dcloud:
+      profile: node
+      count: 1

--- a/stargaze/docker-compose.yml
+++ b/stargaze/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.4'
+
+services:
+  node_1:
+    build:
+      context: ../
+      args:
+        PROJECT: stargaze
+        PROJECT_BIN: starsd
+        PROJECT_DIR: .starsd
+        VERSION: v1.0.0
+        REPOSITORY: https://github.com/public-awesome/stargaze
+        NAMESPACE: STARGAZE
+        WASMVM_VERSION: v0.14.0
+    ports:
+      - '26656:26656'
+      - '26657:26657'
+    environment:
+      - MONIKER=node_1
+      - CHAIN_URL=https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/chain.json
+    env_file:
+      - ../.env
+    volumes:
+      - ./node-data:/root/.starsd


### PR DESCRIPTION
Tested locally using docker compose, and on Akash using a custom image--works great. The Stargaze genesis file in their GitHub repo is in .tar.gz though, and right now only .gz and .zip are supported. It's not unreasonable to also support .tar.gz I suppose, so I added the support in the run.sh and updated the README.

At the time of writing, the chain registry PR is still pending: https://github.com/cosmos/chain-registry/pull/48 