### PR TITLE
fix stargaze namespace in docker compose

### DIFF
--- a/stargaze/docker-compose.yml
+++ b/stargaze/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         PROJECT_DIR: .starsd
         VERSION: v1.0.0
         REPOSITORY: https://github.com/public-awesome/stargaze
-        NAMESPACE: STARGAZE
+        NAMESPACE: STARSD
         WASMVM_VERSION: v0.14.0
     ports:
       - '26656:26656'


### PR DESCRIPTION
Whoops I must have accidentally hit "undo" one too many times before committing--this fixes the namespace in the docker-compose