### PR TITLE
Add optional build steps and migrate Juno

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,48 +17,49 @@ jobs:
             version: v0.12.1
             repository: https://github.com/ovrclk/akash.git
             namespace: AKASH
-            wasmvm_version: main
+            build_env: default
           - project: sentinelhub
             project_bin: sentinelhub
             project_dir: .sentinelhub
             version: v0.8.3
             repository: https://github.com/sentinel-official/hub.git
             namespace: SENTINELHUB
-            wasmvm_version: main
+            build_env: default
           - project: gaia
             project_bin: gaiad
             project_dir: .gaia
             version: v5.0.8
             repository: https://github.com/cosmos/gaia
             namespace: GA
-            wasmvm_version: main
+            build_env: default
           - project: kava
             project_bin: kvd
             project_dir: .kvd
             version: v0.15.1
             repository: https://github.com/Kava-Labs/kava
             namespace: KA
-            wasmvm_version: main
+            build_env: default
           - project: osmosis
             project_bin: osmosisd
             project_dir: .osmosisd
             version: v4.2.0
             repository: https://github.com/osmosis-labs/osmosis
             namespace: OSMOSISD
-            wasmvm_version: main
+            build_env: default
           - project: persistence
             project_bin: persistenceCore
             project_dir: .persistenceCore
             version: v0.1.3
             repository: https://github.com/persistenceOne/persistenceCore
             namespace: PERSISTENCECORE
-            wasmvm_version: main
+            build_env: default
           - project: juno
             project_bin: junod
             project_dir: .juno
             version: v1.0.0
             repository: https://github.com/CosmosContracts/Juno
             namespace: JUNOD
+            build_env: juno
             wasmvm_version: v0.14.0
           - project: regen
             project_bin: regen
@@ -66,42 +67,42 @@ jobs:
             version: v2.0.0
             repository: https://github.com/regen-network/regen-ledger
             namespace: REGEN
-            wasmvm_version: v0.13.0
+            build_env: default
           - project: stargaze
             project_bin: starsd
             project_dir: .starsd
             version: v1.0.0
             repository: https://github.com/public-awesome/stargaze
             namespace: STARSD
-            wasmvm_version: v0.14.0
+            build_env: default
           - project: terra
             project_bin: terrad
             project_dir: .terra
             version: v0.5.9
             repository: https://github.com/terra-money/core
             namespace: TERRAD
-            wasmvm_version: v0.13.0
+            build_env: default
           - project: sifchain
             project_bin: sifnoded
             project_dir: .sifnoded
             version: betanet-0.9.12
             repository: https://github.com/Sifchain/sifnode
             namespace: SIFNODED
-            wasmvm_version: v0.13.0
+            build_env: default
           - project: bitcanna
             project_bin: bcnad
             project_dir: .bcna
             version: v1.2
             repository: https://github.com/BitCannaGlobal/bcna
             namespace: BCNAD
-            wasmvm_version: v0.13.0
+            build_env: default
           - project: emoney
             project_bin: emd
             project_dir: .emd
             version: v1.1.3
             repository: https://github.com/e-money/em-ledger
             namespace: EMD
-            wasmvm_version: v0.13.0
+            build_env: default
     steps:
       - uses: actions/checkout@v2
       - name: build
@@ -114,5 +115,6 @@ jobs:
             --build-arg VERSION=${{matrix.version}} \
             --build-arg REPOSITORY=${{matrix.repository}} \
             --build-arg NAMESPACE=${{matrix.namespace}} \
+            --build-arg BUILD_ENV=${{matrix.build_env}} \
             --build-arg WASMVM_VERSION=${{matrix.wasmvm_version}}
           docker push ghcr.io/${{ github.repository }}:${GITHUB_REF#refs/tags/}-${{matrix.project}}-${{matrix.version}}${{matrix.tag_suffix}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
-FROM golang:1.16-buster AS build
+ARG BUILD_ENV=default
+FROM golang:1.16-buster AS base
 
 RUN apt-get update && \
   apt-get install --no-install-recommends --assume-yes curl unzip && \
   apt-get clean
 
-FROM build AS aws
+FROM base AS aws
 
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 RUN unzip awscliv2.zip -d /usr/src
 
-FROM build AS project
+FROM base AS project
 
 ARG PROJECT=akash
 ARG PROJECT_BIN=$PROJECT
@@ -23,7 +24,7 @@ RUN git checkout $VERSION
 RUN make install
 RUN mv $GOPATH/bin/$PROJECT_BIN /bin/$PROJECT_BIN
 
-FROM debian:buster
+FROM debian:buster AS build_default
 LABEL org.opencontainers.image.source https://github.com/ovrclk/cosmos-omnibus
 
 RUN apt-get update && \
@@ -35,7 +36,6 @@ ARG PROJECT_BIN=$PROJECT
 ARG PROJECT_DIR=.$PROJECT_BIN
 ARG PROJECT_CMD="$PROJECT_BIN start"
 ARG VERSION=v0.12.1
-ARG WASMVM_VERSION=main
 ARG REPOSITORY=https://github.com/ovrclk/akash.git
 ARG NAMESPACE
 
@@ -46,7 +46,6 @@ ENV PROJECT_CMD=$PROJECT_CMD
 ENV VERSION=$VERSION
 ENV REPOSITORY=$REPOSITORY
 ENV NAMESPACE=$NAMESPACE
-ENV WASMVM_VERSION=$WASMVM_VERSION
 
 ENV MONIKER=my-omnibus-node
 
@@ -59,10 +58,18 @@ EXPOSE 26656 \
 COPY --from=project /bin/$PROJECT_BIN /bin/$PROJECT_BIN
 COPY --from=aws /usr/src/aws /usr/src/aws
 RUN /usr/src/aws/install --bin-dir /usr/bin
-ADD https://raw.githubusercontent.com/CosmWasm/wasmvm/$WASMVM_VERSION/api/libwasmvm.so /lib/libwasmvm.so
 
 COPY run.sh snapshot.sh /usr/bin/
 RUN chmod +x /usr/bin/run.sh /usr/bin/snapshot.sh
 ENTRYPOINT ["run.sh"]
 
 CMD $PROJECT_CMD
+
+FROM build_default AS build_juno
+
+ONBUILD ARG WASMVM_VERSION=main
+ONBUILD ENV WASMVM_VERSION=$WASMVM_VERSION
+
+ONBUILD ADD https://raw.githubusercontent.com/CosmWasm/wasmvm/$WASMVM_VERSION/api/libwasmvm.so /lib/libwasmvm.so
+
+FROM build_${BUILD_ENV}

--- a/bitcanna/docker-compose.yml
+++ b/bitcanna/docker-compose.yml
@@ -11,7 +11,6 @@ services:
         VERSION: v1.2
         REPOSITORY: https://github.com/BitCannaGlobal/bcna
         NAMESPACE: BCNAD
-        WASMVM_VERSION: v0.14.0
     ports:
       - '26656:26656'
       - '26657:26657'

--- a/juno/docker-compose.yml
+++ b/juno/docker-compose.yml
@@ -11,6 +11,7 @@ services:
         VERSION: v1.0.0
         REPOSITORY: https://github.com/CosmosContracts/Juno
         NAMESPACE: JUNOD
+        BUILD_ENV: juno
         WASMVM_VERSION: v0.14.0
     ports:
       - '26656:26656'

--- a/stargaze/docker-compose.yml
+++ b/stargaze/docker-compose.yml
@@ -11,7 +11,6 @@ services:
         VERSION: v1.0.0
         REPOSITORY: https://github.com/public-awesome/stargaze
         NAMESPACE: STARSD
-        WASMVM_VERSION: v0.14.0
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
Allows for custom build environments in the Dockerfile which only run if the `BUILD_ENV` argument is set to the named section. Falls back to a default install without running any extra build steps. `ONBUILD` instruction is key here, it only runs the subsequent instruction if that 'branch' is run.

I've migrated the libwasmvm.so install as this was only for Juno. I believe this will be removed in future versions anyway but it's a good example of how to use this feature