### PR TITLE
Add support for Secret Network v1.2.2

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -49,6 +49,8 @@ jobs:
             version: v2.0.0
           - project: rizon
             version: v0.2.8
+          - project: secretnetwork
+            version: v1.2.2
           - project: sentinel
             version: v0.8.3
           - project: shentu

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[persistence](https://github.com/persistenceOne/persistenceCore)|`v0.1.3`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.14-persistence-v0.1.3`|[Example](./persistence)|
 |[regen](https://github.com/regen-network/regen-ledger)|`v2.0.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.14-regen-v2.0.0`|[Example](./regen)|
 |[rizon](https://github.com/rizon-world/rizon)|`v0.2.8`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.14-rizon-v0.2.8`|[Example](./rizon)|
+|[secretnetwork](https://github.com/scrtlabs/SecretNetwork)|`v1.2.2`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.14-secretnetwork-v1.2.2`|[Example](./secretnetwork)|
 |[sentinel](https://github.com/sentinel-official/hub)|`v0.8.3`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.14-sentinel-v0.8.3`|[Example](./sentinel)|
 |[shentu](https://github.com/certikfoundation/shentu)|`v2.2.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.14-shentu-v2.2.0`|[Example](./shentu)|
 |[sifchain](https://github.com/Sifchain/sifnode)|`v0.9.14`|`ghcr.io/ovrclk/cosmos-omnibus:v0.0.14-sifchain-v0.9.14`|[Example](./sifchain)|

--- a/secretnetwork/deploy.yml
+++ b/secretnetwork/deploy.yml
@@ -1,0 +1,45 @@
+---
+version: "2.0"
+
+services:
+  node:
+    image: ghcr.io/ovrclk/cosmos-omnibus:v0.0.14-secretnetwork-v1.2.2
+    env:
+      - MONIKER=node_1
+      - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/chain.json
+    expose:
+      - port: 26657
+        as: 80
+        to:
+          - global: true
+      - port: 26656
+        to:
+          - global: true
+
+profiles:
+  compute:
+    node:
+      resources:
+        cpu:
+          units: 2
+        memory:
+          size: 2Gi
+        storage:
+          size: 60Gi
+  placement:
+    dcloud:
+      attributes:
+        host: akash
+      signedBy:
+        anyOf:
+          - akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63
+      pricing:
+        node:
+          denom: uakt
+          amount: 100
+
+deployment:
+  node:
+    dcloud:
+      profile: node
+      count: 1

--- a/secretnetwork/docker-compose.yml
+++ b/secretnetwork/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.4'
+
+services:
+  node_1:
+    build:
+      context: ../
+      args:
+        PROJECT: secretnetwork
+        PROJECT_BIN: secretd
+        VERSION: v1.2.2
+        REPOSITORY: https://github.com/scrtlabs/SecretNetwork
+        NAMESPACE: SCRT
+        PROJECT_DIR: .secretd
+    environment:
+      - MONIKER=node_1
+      - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/chain.json
+    env_file:
+      - ../.env
+    volumes:
+      - ./node-data:/root/.secretd


### PR DESCRIPTION
Add support for [Secret Network v1.2.2](https://github.com/scrtlabs/SecretNetwork) so you can run Secret Network nodes on Akash.

Refer to the [docs for reference](https://build.scrt.network/validators-and-full-nodes/run-full-node-mainnet.html#run-a-full-node).

Please let me know if there are any important changes to be made, new to setting up Akash containers.

