### PR TITLE
Basic CI tests to ensure project builds

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -64,23 +64,18 @@ jobs:
           - project: thorchain
             version: chaosnet-multichain
     steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v2
-      -
-        uses: docker/setup-buildx-action@v1
+      - uses: actions/checkout@v2
+      - uses: docker/setup-buildx-action@v1
         id: buildx
         with:
           install: true
-      -
-        name: Login to DockerHub
+      - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ secrets.GHCR_USER }}
           password: ${{ secrets.GHCR_TOKEN }}
-      -
-        name: Build
+      - name: Build
         run: |
           touch .env # Create dummy env file
           cd ${{matrix.project}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,52 @@
+name: test
+on:
+  - push
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - project: akash
+          - project: bandchain
+          - project: bitcanna
+          - project: bitsong
+          - project: comdex
+          - project: cosmoshub
+          - project: cryptoorgchain
+          - project: emoney
+          - project: impacthub
+          - project: irisnet
+          - project: juno
+          - project: kava
+          - project: kichain
+          - project: likecoin
+          - project: osmosis
+          - project: panacea
+          - project: persistence
+          - project: regen
+          - project: rizon
+          - project: sentinel
+          - project: shentu
+          - project: sifchain
+          - project: stargaze
+          - project: starname
+          - project: terra
+          - project: thorchain
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        uses: docker/setup-buildx-action@v1
+        id: buildx
+        with:
+          install: true
+      -
+        name: Build
+        run: |
+          touch .env # Create dummy env file
+          cd ${{matrix.project}}
+          docker buildx bake -f docker-compose.yml --set node_1.tags=node

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,5 @@
 name: test
-on:
-  - push
+on: [push, pull_request]
 
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,48 +4,30 @@ on:
 
 
 jobs:
+  build_matrix:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - id: set-matrix
+        run: echo "::set-output name=matrix::$(find * -type f -name docker-compose.yml | xargs dirname | sort | uniq | jq --raw-input . | jq -c --slurp .)"
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+
   build:
+    needs: build_matrix
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        include:
-          - project: akash
-          - project: bandchain
-          - project: bitcanna
-          - project: bitsong
-          - project: comdex
-          - project: cosmoshub
-          - project: cryptoorgchain
-          - project: emoney
-          - project: impacthub
-          - project: irisnet
-          - project: juno
-          - project: kava
-          - project: kichain
-          - project: likecoin
-          - project: osmosis
-          - project: panacea
-          - project: persistence
-          - project: regen
-          - project: rizon
-          - project: sentinel
-          - project: shentu
-          - project: sifchain
-          - project: stargaze
-          - project: starname
-          - project: terra
-          - project: thorchain
+        project: ${{ fromJson(needs.build_matrix.outputs.matrix) }}
+
     steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v2
-      -
-        uses: docker/setup-buildx-action@v1
+      - uses: actions/checkout@v2
+      - uses: docker/setup-buildx-action@v1
         id: buildx
         with:
           install: true
-      -
-        name: Build
+      - name: Build
         run: |
           touch .env # Create dummy env file
           cd ${{matrix.project}}


### PR DESCRIPTION
Relates to #73 but this is just a start, can take this further to actually test the node runs and not just builds.

The dynamic build matrix in this workflow could be useful for the publish workflow in the future