### PR TITLE
Publish the correct Akash version

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         include:
           - project: akash
-            version: v0.12.1
+            version: v0.14.1
           - project: bandchain
             version: v2.3.2
           - project: bitcanna


### PR DESCRIPTION
This is easily missed, would be better to pull from build.yml but would need to parse it