### PR TITLE
Disable nomic publish for now

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,8 +51,8 @@ jobs:
             version: 2.0.0
           - project: likecoin
             version: fotan-1.1
-          - project: nomic
-            version: stakenet
+          # - project: nomic
+          #   version: stakenet
           - project: osmosis
             version: v6.1.0
           - project: panacea


### PR DESCRIPTION
Build dependencies are failing, will re-enable when fixed