### PR TITLE
Disable Terra for now

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,8 +93,8 @@ jobs:
             version: v1.1.2
           - project: starname
             version: v0.10.18
-          - project: terra
-            version: v0.5.18
+          # - project: terra
+          #   version: v0.5.18
           - project: thorchain
             version: chaosnet-multichain
           - project: umee

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: set-matrix
-        run: echo "::set-output name=matrix::$(find * -type f -name build.yml -not -path "nomic*" | xargs dirname | sort | uniq | jq --raw-input . | jq -c --slurp .)"
+        run: echo "::set-output name=matrix::$(find * -type f -name build.yml -not -path "nomic*" -not -path "terra*" | xargs dirname | sort | uniq | jq --raw-input . | jq -c --slurp .)"
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[sommelier](https://github.com/PeggyJV/sommelier)|`v3.1.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.1.4-sommelier-v3.1.0`|[Example](./sommelier)|
 |[stargaze](https://github.com/public-awesome/stargaze)|`v1.1.2`|`ghcr.io/ovrclk/cosmos-omnibus:v0.1.4-stargaze-v1.1.2`|[Example](./stargaze)|
 |[starname](https://github.com/iov-one/starnamed)|`v0.10.18`|`ghcr.io/ovrclk/cosmos-omnibus:v0.1.4-starname-v0.10.18`|[Example](./starname)|
-|[terra](https://github.com/terra-money/core)|`v0.5.18`|`ghcr.io/ovrclk/cosmos-omnibus:v0.1.4-terra-v0.5.18`|[Example](./terra)|
 |[thorchain](https://gitlab.com/thorchain/thornode)|`chaosnet-multichain`|`ghcr.io/ovrclk/cosmos-omnibus:v0.1.4-thorchain-chaosnet-multichain`|[Example](./thorchain)|
 |[umee](https://github.com/umee-network/umee)|`v1.0.1`|`ghcr.io/ovrclk/cosmos-omnibus:v0.1.4-umee-v1.0.1`|[Example](./umee)|
 |[vidulum](https://github.com/vidulum/mainnet)|`v1.0.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.1.4-vidulum-v1.0.0`|[Example](./vidulum)|


### PR DESCRIPTION
Terra have replaced their repository with a new version, without tags/versions etc. 

For now we'll remove it from Omnibus until things settle, and we can reliably build it again. It prevents builds otherwise. 

See https://github.com/terra-money/core