### PR TITLE
Remove double env: block declaration

### DIFF
--- a/_examples/validator-and-private-sentries/deploy.yml
+++ b/_examples/validator-and-private-sentries/deploy.yml
@@ -5,7 +5,6 @@ services:
   validator:
     image: ghcr.io/ovrclk/cosmos-omnibus:v0.1.5-akash-v0.16.3
     env:
-    env:
       - MONIKER=validator
       - CHAIN_JSON=https://raw.githubusercontent.com/ovrclk/net/master/mainnet/meta.json
       - MINIMUM_GAS_PRICES=0.025uakt


### PR DESCRIPTION
In commit 3560e5dd80770ad79c1dbff24342310384307a62 this file got added with two env: block declarations

https://github.com/ovrclk/cosmos-omnibus/commit/3560e5dd80770ad79c1dbff24342310384307a62#diff-e5b3a0a89d03cfcb34af3100ac13b2c528fd98e781e1bc8caf427a14d3d60afbR7