### PR TITLE
fix: Set Cronos version to v0.7.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
           - project: cosmoshub
             version: v7.0.1
           - project: cronos
-            version: v0.6.5
+            version: v0.7.0
           - project: cryptoorgchain
             version: v3.3.3
           - project: decentr

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[chihuahua](https://github.com/ChihuahuaChain/chihuahua)|`v1.1.1`|`ghcr.io/ovrclk/cosmos-omnibus:v0.1.6-chihuahua-v1.1.1`|[Example](./chihuahua)|
 |[comdex](https://github.com/comdex-official/comdex)|`v0.1.1`|`ghcr.io/ovrclk/cosmos-omnibus:v0.1.6-comdex-v0.1.1`|[Example](./comdex)|
 |[cosmoshub](https://github.com/cosmos/gaia)|`v7.0.1`|`ghcr.io/ovrclk/cosmos-omnibus:v0.1.6-cosmoshub-v7.0.1`|[Example](./cosmoshub)|
-|[cronos](https://github.com/crypto-org-chain/cronos)|`v0.6.5`|`ghcr.io/ovrclk/cosmos-omnibus:v0.1.6-cronos-v0.6.5`|[Example](./cronos)|
+|[cronos](https://github.com/crypto-org-chain/cronos)|`v0.7.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.1.6-cronos-v0.7.0`|[Example](./cronos)|
 |[cryptoorgchain](https://github.com/crypto-org-chain/chain-main)|`v3.3.3`|`ghcr.io/ovrclk/cosmos-omnibus:v0.1.6-cryptoorgchain-v3.3.3`|[Example](./cryptoorgchain)|
 |[decentr](https://github.com/Decentr-net/decentr)|`v1.5.7`|`ghcr.io/ovrclk/cosmos-omnibus:v0.1.6-decentr-v1.5.7`|[Example](./decentr)|
 |[defund](https://github.com/defund-labs/defund)|`v0.0.2`|`ghcr.io/ovrclk/cosmos-omnibus:v0.1.6-defund-v0.0.2`|[Example](./defund)|

--- a/cronos/README.md
+++ b/cronos/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v0.6.5`|
+|Version|`v0.7.0`|
 |Binary|`cronosd`|
 |Directory|`.cronos`|
 |ENV namespace|`CRONOS`|
 |Repository|`https://github.com/crypto-org-chain/cronos`|
-|Image|`ghcr.io/ovrclk/cosmos-omnibus:v0.1.6-cronos-v0.6.5`|
+|Image|`ghcr.io/ovrclk/cosmos-omnibus:v0.1.6-cronos-v0.7.0`|
 
 ## Examples
 

--- a/cronos/build.yml
+++ b/cronos/build.yml
@@ -8,7 +8,7 @@ services:
         PROJECT: cronos
         PROJECT_BIN: cronosd
         PROJECT_DIR: .cronos
-        VERSION: v0.6.5
+        VERSION: v0.7.0
         REPOSITORY: https://github.com/crypto-org-chain/cronos
         NAMESPACE: CRONOS
     ports:

--- a/cronos/deploy.yml
+++ b/cronos/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/ovrclk/cosmos-omnibus:v0.1.6-cronos-v0.6.5
+    image: ghcr.io/ovrclk/cosmos-omnibus:v0.1.6-cronos-v0.7.0
     env:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/cronos/chain.json

--- a/cronos/docker-compose.yml
+++ b/cronos/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/ovrclk/cosmos-omnibus:v0.1.6-cronos-v0.6.5
+    image: ghcr.io/ovrclk/cosmos-omnibus:v0.1.6-cronos-v0.7.0
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
Cronos' binary version should be 0.7.0, as recorded in chain-registry: https://github.com/cosmos/chain-registry/pull/399