### PR TITLE
Fix shentu project volume directory

### DIFF
--- a/shentu/README.md
+++ b/shentu/README.md
@@ -5,7 +5,7 @@
 |Version|`v2.2.0`|
 |Binary|`certik`|
 |Directory|`.certik`|
-|ENV namespace|`SHENTU`|
+|ENV namespace|`CERTIK`|
 |Repository|`https://github.com/certikfoundation/shentu`|
 |Image|`ghcr.io/ovrclk/cosmos-omnibus:v0.2.2-shentu-v2.2.0`|
 

--- a/shentu/build.yml
+++ b/shentu/build.yml
@@ -10,7 +10,7 @@ services:
         PROJECT_DIR: .certik
         VERSION: v2.2.0
         REPOSITORY: https://github.com/certikfoundation/shentu
-        NAMESPACE: SHENTU
+        NAMESPACE: CERTIK
     ports:
       - '26656:26656'
       - '26657:26657'
@@ -24,4 +24,4 @@ services:
     env_file:
       - ../.env
     volumes:
-      - ./node-data:/root/.shentu
+      - ./node-data:/root/.certik

--- a/shentu/docker-compose.yml
+++ b/shentu/docker-compose.yml
@@ -14,4 +14,4 @@ services:
       # - STATESYNC_POLKACHU=1
       - SNAPSHOT_POLKACHU=1
     volumes:
-      - ./node-data:/root/.shentu
+      - ./node-data:/root/.certik


### PR DESCRIPTION
This fixed will enable proper edits to the config files (peers,seeds) to the certik project directory. Previously it did not register the env variables indicated by user due to incorrect project file directory