### PR TITLE
Update fetchd version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,7 +56,7 @@ jobs:
           - project: evmos
             version: v4.0.1
           - project: fetchhub
-            version: v0.9.1
+            version: v0.10.4
           - project: gravitybridge
             version: v1.4.1
           - project: impacthub

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[dig](https://github.com/notional-labs/dig)|`v2.0.1`|`ghcr.io/ovrclk/cosmos-omnibus:v0.2.3-dig-v2.0.1`|[Example](./dig)|
 |[emoney](https://github.com/e-money/em-ledger)|`v1.1.4`|`ghcr.io/ovrclk/cosmos-omnibus:v0.2.3-emoney-v1.1.4`|[Example](./emoney)|
 |[evmos](https://github.com/tharsis/evmos)|`v4.0.1`|`ghcr.io/ovrclk/cosmos-omnibus:v0.2.3-evmos-v4.0.1`|[Example](./evmos)|
-|[fetchhub](https://github.com/fetchai/fetchd)|`v0.9.1`|`ghcr.io/ovrclk/cosmos-omnibus:v0.2.3-fetchhub-v0.9.1`|[Example](./fetchhub)|
+|[fetchhub](https://github.com/fetchai/fetchd)|`v0.10.4`|`ghcr.io/ovrclk/cosmos-omnibus:v0.2.3-fetchhub-v0.10.4`|[Example](./fetchhub)|
 |[gravitybridge](https://github.com/Gravity-Bridge/Gravity-Bridge)|`v1.4.1`|`ghcr.io/ovrclk/cosmos-omnibus:v0.2.3-gravitybridge-v1.4.1`|[Example](./gravitybridge)|
 |[impacthub](https://github.com/ixofoundation/ixo-blockchain)|`v0.17.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.2.3-impacthub-v0.17.0`|[Example](./impacthub)|
 |[irisnet](https://github.com/irisnet/irishub)|`v1.0.1`|`ghcr.io/ovrclk/cosmos-omnibus:v0.2.3-irisnet-v1.0.1`|[Example](./irisnet)|

--- a/fetchhub/README.md
+++ b/fetchhub/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v0.9.1`|
+|Version|`v0.10.4`|
 |Binary|`fetchd`|
 |Directory|`.fetchd`|
 |ENV namespace|`FETCH`|
 |Repository|`https://github.com/fetchai/fetchd`|
-|Image|`ghcr.io/ovrclk/cosmos-omnibus:v0.2.3-fetchhub-v0.9.1`|
+|Image|`ghcr.io/ovrclk/cosmos-omnibus:v0.2.3-fetchhub-v0.10.4`|
 
 ## Examples
 

--- a/fetchhub/build.yml
+++ b/fetchhub/build.yml
@@ -8,7 +8,7 @@ services:
         PROJECT: fetchhub
         PROJECT_BIN: fetchd
         PROJECT_DIR: .fetchd
-        VERSION: v0.9.1
+        VERSION: v0.10.4
         REPOSITORY: https://github.com/fetchai/fetchd
         NAMESPACE: FETCHHUB
     ports:

--- a/fetchhub/deploy.yml
+++ b/fetchhub/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/ovrclk/cosmos-omnibus:v0.2.3-fetchhub-v0.9.1
+    image: ghcr.io/ovrclk/cosmos-omnibus:v0.2.3-fetchhub-v0.10.4
     env:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/chain.json

--- a/fetchhub/docker-compose.yml
+++ b/fetchhub/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/ovrclk/cosmos-omnibus:v0.2.3-fetchhub-v0.9.1
+    image: ghcr.io/ovrclk/cosmos-omnibus:v0.2.3-fetchhub-v0.10.4
     ports:
       - '26656:26656'
       - '26657:26657'
@@ -14,4 +14,4 @@ services:
       # - STATESYNC_POLKACHU=1
       - SNAPSHOT_POLKACHU=1
     volumes:
-      - ./node-data:/root/.cronos
+      - ./node-data:/root/.fetchd


### PR DESCRIPTION
Presented fetchhub version 0.9.1 doesn't work because of consensus-breaking release 0.10.4
Also fix node-data directory name