### PR TITLE
Update Juno v9.0.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,7 +64,7 @@ jobs:
           - project: irisnet
             version: v1.0.1
           - project: juno
-            version: v8.0.0
+            version: v9.0.0
           - project: kava
             version: v0.16.1
           - project: kichain

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[gravitybridge](https://github.com/Gravity-Bridge/Gravity-Bridge)|`v1.4.1`|`ghcr.io/ovrclk/cosmos-omnibus:v0.2.7-gravitybridge-v1.4.1`|[Example](./gravitybridge)|
 |[impacthub](https://github.com/ixofoundation/ixo-blockchain)|`v0.17.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.2.7-impacthub-v0.17.0`|[Example](./impacthub)|
 |[irisnet](https://github.com/irisnet/irishub)|`v1.0.1`|`ghcr.io/ovrclk/cosmos-omnibus:v0.2.7-irisnet-v1.0.1`|[Example](./irisnet)|
-|[juno](https://github.com/CosmosContracts/Juno)|`v8.0.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.2.7-juno-v8.0.0`|[Example](./juno)|
+|[juno](https://github.com/CosmosContracts/Juno)|`v9.0.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.2.7-juno-v9.0.0`|[Example](./juno)|
 |[kava](https://github.com/Kava-Labs/kava)|`v0.16.1`|`ghcr.io/ovrclk/cosmos-omnibus:v0.2.7-kava-v0.16.1`|[Example](./kava)|
 |[kixchain](https://github.com/KiFoundation/ki-tools)|`3.0.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.2.7-kichain-3.0.0`|[Example](./kichain)|
 |[konstellation](https://github.com/konstellation/konstellation)|`0.5.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.2.7-konstellation-0.5.0`|[Example](./konstellation)|

--- a/juno/README.md
+++ b/juno/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v8.0.0`|
+|Version|`v9.0.0`|
 |Binary|`junod`|
 |Directory|`.juno`|
 |ENV namespace|`JUNOD`|
 |Repository|`https://github.com/CosmosContracts/Juno`|
-|Image|`ghcr.io/ovrclk/cosmos-omnibus:v0.2.7-juno-v8.0.0`|
+|Image|`ghcr.io/ovrclk/cosmos-omnibus:v0.2.7-juno-v9.0.0`|
 
 ## Examples
 

--- a/juno/build.yml
+++ b/juno/build.yml
@@ -11,6 +11,7 @@ services:
         VERSION: v9.0.0
         BUILD_IMAGE: binary
         BINARY_URL: https://github.com/CosmosContracts/juno/releases/download/v9.0.0/junod
+        GOLANG_VERSION: 1.18-buster
     ports:
       - '26656:26656'
       - '26657:26657'

--- a/juno/build.yml
+++ b/juno/build.yml
@@ -8,9 +8,9 @@ services:
         PROJECT: juno
         PROJECT_BIN: junod
         PROJECT_DIR: .juno
-        VERSION: v8.0.0
+        VERSION: v9.0.0
         BUILD_IMAGE: binary
-        BINARY_URL: https://github.com/CosmosContracts/juno/releases/download/v8.0.0/junod
+        BINARY_URL: https://github.com/CosmosContracts/juno/releases/download/v9.0.0/junod
     ports:
       - '26656:26656'
       - '26657:26657'

--- a/juno/build.yml
+++ b/juno/build.yml
@@ -9,8 +9,8 @@ services:
         PROJECT_BIN: junod
         PROJECT_DIR: .juno
         VERSION: v9.0.0
-        BUILD_IMAGE: binary
-        BINARY_URL: https://github.com/CosmosContracts/juno/releases/download/v9.0.0/junod
+        REPOSITORY: https://github.com/CosmosContracts/juno
+        NAMESPACE: JUNOD
         GOLANG_VERSION: 1.18-buster
     ports:
       - '26656:26656'
@@ -19,6 +19,8 @@ services:
     environment:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/chain.json
+      - GENESIS_URL=https://download.dimi.sh/juno-phoenix2-genesis.tar.gz
+      - GENESIS_FILENAME=juno-phoenix2-genesis.json
       - P2P_POLKACHU=1
       - STATESYNC_POLKACHU=1
       # - SNAPSHOT_POLKACHU=1

--- a/juno/deploy.yml
+++ b/juno/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/ovrclk/cosmos-omnibus:v0.2.7-juno-v8.0.0
+    image: ghcr.io/ovrclk/cosmos-omnibus:v0.2.7-juno-v9.0.0
     env:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/chain.json

--- a/juno/deploy.yml
+++ b/juno/deploy.yml
@@ -7,6 +7,8 @@ services:
     env:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/chain.json
+      - GENESIS_URL=https://download.dimi.sh/juno-phoenix2-genesis.tar.gz
+      - GENESIS_FILENAME=juno-phoenix2-genesis.json
       - P2P_POLKACHU=1
       # - STATESYNC_POLKACHU=1
       - SNAPSHOT_POLKACHU=1

--- a/juno/docker-compose.yml
+++ b/juno/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/ovrclk/cosmos-omnibus:v0.2.7-juno-v8.0.0
+    image: ghcr.io/ovrclk/cosmos-omnibus:v0.2.7-juno-v9.0.0
     ports:
       - '26656:26656'
       - '26657:26657'

--- a/juno/docker-compose.yml
+++ b/juno/docker-compose.yml
@@ -10,6 +10,8 @@ services:
     environment:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/chain.json
+      - GENESIS_URL=https://download.dimi.sh/juno-phoenix2-genesis.tar.gz
+      - GENESIS_FILENAME=juno-phoenix2-genesis.json
       - P2P_POLKACHU=1
       # - STATESYNC_POLKACHU=1
       - SNAPSHOT_POLKACHU=1

--- a/run.sh
+++ b/run.sh
@@ -208,6 +208,8 @@ fi
 
 # Download genesis
 if [ "$DOWNLOAD_GENESIS" == "1" ]; then
+  GENESIS_FILENAME="${GENESIS_FILENAME:-genesis.json}"
+
   echo "Downloading genesis $GENESIS_URL"
   curl -sfL $GENESIS_URL > genesis.json
   file genesis.json | grep -q 'gzip compressed data' && mv genesis.json genesis.json.gz && gzip -d genesis.json.gz
@@ -215,7 +217,7 @@ if [ "$DOWNLOAD_GENESIS" == "1" ]; then
   file genesis.json | grep -q 'Zip archive data' && mv genesis.json genesis.json.zip && unzip -o genesis.json.zip
 
   mkdir -p $CONFIG_PATH
-  mv genesis.json $CONFIG_PATH/genesis.json
+  mv $GENESIS_FILENAME $CONFIG_PATH/genesis.json
 fi
 
 # Snapshot


### PR DESCRIPTION
- Install Juno from source and update to v9.0.0
- Update Juno genesis URL for the time being
- Support non-standard genesis filename when extracting
