### PR TITLE
Add support for zstd snapshots

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,32 @@ ARG BINARY_URL
 RUN curl -Lo /bin/$PROJECT_BIN $BINARY_URL
 RUN chmod +x /bin/$PROJECT_BIN
 
+FROM gcc:12 AS zstd_build
+
+ARG ZTSD_SOURCE_URL="https://github.com/facebook/zstd/releases/download/v1.5.2/zstd-1.5.2.tar.gz"
+
+RUN apt-get update && \
+      apt-get install --no-install-recommends --assume-yes python3 ninja-build && \
+      apt-get clean && \
+    curl -o /tmp/get-pip.py -L 'https://bootstrap.pypa.io/get-pip.py' && \
+      python3 /tmp/get-pip.py && \
+    pip3 install meson && \
+    mkdir -p /tmp/zstd && \
+    cd /tmp/zstd && \
+    curl -Lo zstd.source $ZTSD_SOURCE_URL && \
+    file zstd.source | grep -q 'gzip compressed data' && mv zstd.source zstd.source.gz && gzip -d zstd.source.gz && \
+    file zstd.source | grep -q 'tar archive' && mv zstd.source zstd.source.tar && tar -xf zstd.source.tar --strip-components=1 && rm zstd.source.tar && \
+    LDFLAGS=-static \
+    meson setup \
+      -Dbin_programs=true \
+      -Dstatic_runtime=true \
+      -Ddefault_library=static \
+      -Dzlib=disabled -Dlzma=disabled -Dlz4=disabled \
+      build/meson builddir-st && \
+    ninja -C builddir-st && \
+    ninja -C builddir-st install && \
+    /usr/local/bin/zstd -v
+
 #
 # Final Omnibus image
 # Note optional `BUILD_IMAGE` argument controls the base image
@@ -92,6 +118,8 @@ LABEL org.opencontainers.image.source https://github.com/ovrclk/cosmos-omnibus
 RUN apt-get update && \
   apt-get install --no-install-recommends --assume-yes ca-certificates curl wget file unzip liblz4-tool gnupg2 jq && \
   apt-get clean
+
+COPY --from=zstd_build /usr/local/bin/zstd /bin/
 
 ARG PROJECT
 ARG PROJECT_BIN

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Note that snapshots will be restored in-process, without downloading the snapsho
 |`SNAPSHOT_URL`|A URL to a `.tar`, `.tar.gz` or `.lz4` file| |`http://135.181.60.250/akash/akashnet-2_2021-06-16.tar`|
 |`SNAPSHOT_BASE_URL`|A base URL to a directory containing backup files| |`http://135.181.60.250/akash`|
 |`SNAPSHOT_JSON`|A URL to a `snapshot.json` as detailed in [Snapshot backup](#snapshot-backup)| |`https://cosmos-snapshots.s3.filebase.com/akash/pruned/snapshot.json`|
-|`SNAPSHOT_FORMAT`|The format of the snapshot file|`tar.gz`|`tar`|
+|`SNAPSHOT_FORMAT`|The format of the snapshot file|`tar.gz`|`tar`/`tar.zst`|
 |`SNAPSHOT_PATTERN`|The pattern of the file in the `SNAPSHOT_BASE_URL`|`$CHAIN_ID.*$SNAPSHOT_FORMAT`|`foobar.*tar.gz`|
 |`SNAPSHOT_DATA_PATH`|The path to the data directory within the archive| |`snapshot/data`|
 |`SNAPSHOT_PRUNING`|Type of snapshot to download, e.g. `archive`, `pruned`, `default`.|`pruned`|`archive`|
@@ -260,7 +260,11 @@ Snapshots older than a specified time can also be deleted. Finally a JSON metada
 |`SNAPSHOT_RETAIN`|How long to retain snapshots for (0 to disable)|`2 days`|`1 week`|
 |`SNAPSHOT_METADATA`|Whether to create a snapshot.json metadata file|`1`|`0`|
 |`SNAPSHOT_METADATA_URL`|The URL snapshots will be served from (for snapshot.json)| |`https://cosmos-snapshots.s3.filebase.com/akash`|
-|`SNAPSHOT_SAVE_FORMAT`|To override the `SNAPSHOT_FORMAT`.|`tar.gz`|`tar` (to disable compression)|
+|`SNAPSHOT_SAVE_FORMAT`|Overrides value from `SNAPSHOT_FORMAT`.|`tar.gz`|`tar` (no compression)/`tar.zst` (use [zstd](https://github.com/facebook/zstd))|
+
+When `SNAPSHOT_SAVE_FORMAT` is set to `tar.zst`, [additional variables can be set](https://github.com/facebook/zstd/tree/v1.5.2/programs#passing-parameters-through-environment-variables):
+- `ZSTD_CLEVEL` - Compression level, default `3`
+- `ZSTD_NBTHREADS` - No. of threads, default `1`, `0` = detected no. of cpu cores
 
 ### Binary download
 

--- a/run.sh
+++ b/run.sh
@@ -246,8 +246,12 @@ if [ "$DOWNLOAD_SNAPSHOT" == "1" ]; then
     mkdir -p $PROJECT_ROOT/data;
     cd $PROJECT_ROOT/data
 
-    [[ $SNAPSHOT_FORMAT = "tar.gz" ]] && tar_args="xzf" || tar_args="xf"
-    [[ $SNAPSHOT_FORMAT = "lz4" ]] && tar_cmd="lz4 -d | tar $tar_args -" || tar_cmd="tar $tar_args -"
+    tar_args="xf"
+    tar_cmd="tar $tar_args -"
+    # case insensitive match
+    if [[ "${SNAPSHOT_FORMAT,,}" == "tar.gz" ]]; then tar_args="xzf"; fi
+    if [[ "${SNAPSHOT_FORMAT,,}" == "lz4" ]]; then tar_cmd="lz4 -d | tar $tar_args -"; fi
+    if [[ "${SNAPSHOT_FORMAT,,}" == "tar.zst" ]]; then tar_cmd="zstd -cd | tar $tar_args -"; fi
     wget -nv -O - $SNAPSHOT_URL | eval $tar_cmd
     [ -n "${SNAPSHOT_DATA_PATH}" ] && mv ./${SNAPSHOT_DATA_PATH}/* ./ && rm -rf ./${SNAPSHOT_DATA_PATH}
   else

--- a/run.sh
+++ b/run.sh
@@ -222,7 +222,6 @@ fi
 
 # Snapshot
 if [ "$DOWNLOAD_SNAPSHOT" == "1" ]; then
-  SNAPSHOT_FORMAT="${SNAPSHOT_FORMAT:-tar.gz}"
 
   if [ -z "${SNAPSHOT_URL}" ] && [ -n "${SNAPSHOT_BASE_URL}" ]; then
     SNAPSHOT_PATTERN="${SNAPSHOT_PATTERN:-$CHAIN_ID.*$SNAPSHOT_FORMAT}"
@@ -236,9 +235,19 @@ if [ "$DOWNLOAD_SNAPSHOT" == "1" ]; then
   if [ -z "${SNAPSHOT_URL}" ] && [ -n "${SNAPSHOT_QUICKSYNC}" ]; then
     SNAPSHOT_PRUNING="${SNAPSHOT_PRUNING:-pruned}"
     SNAPSHOT_DATA_PATH="data"
-    SNAPSHOT_FORMAT="lz4"
     SNAPSHOT_URL=`curl -s $SNAPSHOT_QUICKSYNC | jq -r --arg FILE "$CHAIN_ID-$SNAPSHOT_PRUNING"  'first(.[] | select(.file==$FILE)) | .url'`
   fi
+
+  # SNAPSHOT_FORMAT default value generation via SNAPSHOT_URL
+  SNAPSHOT_FORMAT_DEFAULT="tar.gz"
+  case "${SNAPSHOT_URL,,}" in
+    *.tar.gz)   SNAPSHOT_FORMAT_DEFAULT="tar.gz";;
+    *.tar.lz4)  SNAPSHOT_FORMAT_DEFAULT="tar.lz4";;
+    *.tar.zst)  SNAPSHOT_FORMAT_DEFAULT="tar.zst";;
+    # Catchall
+    *)          SNAPSHOT_FORMAT_DEFAULT="tar";;
+  esac
+  SNAPSHOT_FORMAT="${SNAPSHOT_FORMAT:-$SNAPSHOT_FORMAT_DEFAULT}"
 
   if [ -n "${SNAPSHOT_URL}" ]; then
     echo "Downloading snapshot from $SNAPSHOT_URL..."
@@ -250,7 +259,7 @@ if [ "$DOWNLOAD_SNAPSHOT" == "1" ]; then
     tar_cmd="tar $tar_args -"
     # case insensitive match
     if [[ "${SNAPSHOT_FORMAT,,}" == "tar.gz" ]]; then tar_args="xzf"; fi
-    if [[ "${SNAPSHOT_FORMAT,,}" == "lz4" ]]; then tar_cmd="lz4 -d | tar $tar_args -"; fi
+    if [[ "${SNAPSHOT_FORMAT,,}" == "tar.lz4" ]]; then tar_cmd="lz4 -d | tar $tar_args -"; fi
     if [[ "${SNAPSHOT_FORMAT,,}" == "tar.zst" ]]; then tar_cmd="zstd -cd | tar $tar_args -"; fi
     wget -nv -O - $SNAPSHOT_URL | eval $tar_cmd
     [ -n "${SNAPSHOT_DATA_PATH}" ] && mv ./${SNAPSHOT_DATA_PATH}/* ./ && rm -rf ./${SNAPSHOT_DATA_PATH}

--- a/run.sh
+++ b/run.sh
@@ -127,7 +127,6 @@ if [[ -n "$P2P_POLKACHU" || -n "$SNAPSHOT_POLKACHU" || -n "$STATESYNC_POLKACHU" 
       if [ $POLKACHU_SNAPSHOT_ENABLED ]; then
         export POLKACHU_SNAPSHOT=`curl -Ls $(echo $POLKACHU_CHAIN | jq -r '.snapshot.endpoint') | jq -r '.snapshot.url'`
         export SNAPSHOT_URL=$POLKACHU_SNAPSHOT
-        export SNAPSHOT_FORMAT=lz4
         export SNAPSHOT_DATA_PATH=data
       else
         echo "Polkachu snapshot is not active for this chain"

--- a/snapshot.sh
+++ b/snapshot.sh
@@ -19,7 +19,10 @@ fi
 # Actual valid values not documented
 # 27 is default value
 # 31 is max value mentioned in project issues
-valid_zstd_long_values=(27 28 29 30 31)
+# Since value > 27 requires special handling on decompression
+# Only 27 is allowed at the moment when enabled
+# See https://github.com/facebook/zstd/blob/v1.5.2/programs/zstd.1.md for more info
+valid_zstd_long_values=(27)
 # If non empty string and invalid value detected
 # Set to default value assuming long should be enabled
 if [ -n "$ZSTD_LONG" ] && ! echo "${valid_zstd_long_values[@]}" | grep -qiw -- "$ZSTD_LONG"; then

--- a/snapshot.sh
+++ b/snapshot.sh
@@ -11,9 +11,9 @@ SNAPSHOT_PREFIX="${SNAPSHOT_PREFIX:-$CHAIN_ID}"
 SNAPSHOT_RETAIN="${SNAPSHOT_RETAIN:-2 days}"
 SNAPSHOT_METADATA="${SNAPSHOT_METADATA:-1}"
 SNAPSHOT_SAVE_FORMAT="${SNAPSHOT_SAVE_FORMAT:-$SNAPSHOT_FORMAT}"
-valid_snapshot_formats=(tar tar.gz)
+valid_snapshot_formats=(tar tar.gz tar.zst)
 # If not one of valid format values, set it to default value
-if ! echo ${valid_snapshot_formats[@]} | grep -qiw -- "$SNAPSHOT_SAVE_FORMAT"; then
+if ! echo "${valid_snapshot_formats[@]}" | grep -qiw -- "$SNAPSHOT_SAVE_FORMAT"; then
   SNAPSHOT_SAVE_FORMAT=tar.gz
 fi
 
@@ -40,12 +40,15 @@ while true; do
         s3_uri="${s3_uri_base}/${SNAPSHOT_PREFIX}_${timestamp}.${SNAPSHOT_SAVE_FORMAT}"
 
         SNAPSHOT_SIZE=$(du -sb $SNAPSHOT_DIR | cut -f1)
-        if [ "$SNAPSHOT_SAVE_FORMAT" == "tar.gz" ]; then
-            (tar c -C $SNAPSHOT_DIR . | gzip -1 | pv -petrafb -i 5 -s $SNAPSHOT_SIZE | aws $aws_args s3 cp - "$s3_uri" --expected-size $SNAPSHOT_SIZE) 2>&1 | stdbuf -o0 tr '\r' '\n'
-        else
-            # `SNAPSHOT_SAVE_FORMAT` should be `tar`
-            (tar c -C $SNAPSHOT_DIR . | pv -petrafb -i 5 -s $SNAPSHOT_SIZE | aws $aws_args s3 cp - "$s3_uri" --expected-size $SNAPSHOT_SIZE) 2>&1 | stdbuf -o0 tr '\r' '\n'
-        fi
+
+        case "${SNAPSHOT_SAVE_FORMAT,,}" in
+          tar.gz)   (tar c -C $SNAPSHOT_DIR . | gzip -1 | pv -petrafb -i 5 -s $SNAPSHOT_SIZE | aws $aws_args s3 cp - "$s3_uri" --expected-size $SNAPSHOT_SIZE) 2>&1 | stdbuf -o0 tr '\r' '\n';;
+          # Compress level can be set via `ZSTD_CLEVEL`, default `3`
+          # No. of threads can be set via `ZSTD_NBTHREADS`, default `1`, `0` = detected no. of cpu cores
+          tar.zst)  (tar c -C $SNAPSHOT_DIR . | zstd -c | pv -petrafb -i 5 -s $SNAPSHOT_SIZE | aws $aws_args s3 cp - "$s3_uri" --expected-size $SNAPSHOT_SIZE) 2>&1 | stdbuf -o0 tr '\r' '\n';;
+          # Catchall, assume to be tar
+          *)        (tar c -C $SNAPSHOT_DIR . | pv -petrafb -i 5 -s $SNAPSHOT_SIZE | aws $aws_args s3 cp - "$s3_uri" --expected-size $SNAPSHOT_SIZE) 2>&1 | stdbuf -o0 tr '\r' '\n';;
+        esac
 
         if [[ $SNAPSHOT_RETAIN != "0" || $SNAPSHOT_METADATA != "0" ]]; then
             readarray -t s3Files < <(aws $aws_args s3 ls "${s3_uri_base}/${SNAPSHOT_PREFIX}_")


### PR DESCRIPTION
Both snapshots usage and producing

Some bash code can be "tested" via https://www.onlinegdb.com/online_bash_shell with the example bash code inside commit messages

Tested with likecoin testnet

Also tested different `ZSTD_CLEVEL`, below screenshot shows file size with level 3, 1, 19 (default 3 if unset)
https://github.com/facebook/zstd/tree/v1.5.2/programs#passing-parameters-through-environment-variables
![image](https://user-images.githubusercontent.com/1018543/184897645-8f87b06e-3b56-44dc-9565-89d23cc60bf1.png)

Documents not updated yet but will be done tomorrow (22:00 a.t.m.)


### `ztsd` installation method choice
I have checked the easy way first (install via package manager)
But [the version available to debian buster is `1.3.8`](https://packages.debian.org/buster/zstd) which is [released on 28 Dec 2018](https://github.com/facebook/zstd/releases/tag/v1.3.8)

[1.5.0](https://github.com/facebook/zstd/releases/tag/v1.5.0) (and 1.5.x) is released with large performance improvement (claimed in released description) and there might be options that are only introduced in recent versions

Regarding use of gcc instead of clang
I read this: https://github.com/facebook/zstd/issues/2695 (which also contains a linked issue with benchmark)

I can't say which compiler or version is better for performance (especially it might depend on the compression level and/or other options to be used) so I just go with latest `gcc`
Let me know if anyone got better idea at this

