### PR TITLE
introduce DEBUG=2 for shell script debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ See [Cosmos docs](https://docs.tendermint.com/master/nodes/configuration.html) f
 |`FASTSYNC_VERSION`|The fastsync version| |`v2`|
 |`MINIMUM_GAS_PRICES`|Minimum gas prices| |`0.025uakt`|
 |`PRUNING`|How much of the chain to prune| |`nothing`|
-|`DEBUG`|Set to `1` to output all environment variables on boot| |`1`|
+|`DEBUG`|Set to `1` to output all environment variables on boot. Set to `2` to debug shell scripts.| |`1`, `2`|
 
 ## Contributing
 

--- a/run.sh
+++ b/run.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+[ "$DEBUG" == "2" ] && set -x
+
 export CHAIN_JSON="${CHAIN_JSON:-$CHAIN_URL}" # deprecate CHAIN_URL
 if [ -n "$CHAIN_JSON" ]; then
   CHAIN_METADATA=$(curl -s $CHAIN_JSON)

--- a/snapshot.sh
+++ b/snapshot.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+[ "$DEBUG" == "2" ] && set -x
+
 SNAPSHOT_TIME="${SNAPSHOT_TIME:-00:00:00}"
 SNAPSHOT_DAY="${SNAPSHOT_DAY:-*}"
 SNAPSHOT_DIR="${SNAPSHOT_DIR:-$PROJECT_ROOT/data}"


### PR DESCRIPTION
helped me to figure why I had `parse error: Invalid numeric literal at line 1, column 6` line below:

```
arno-node-1  | Downloading genesis https://raw.githubusercontent.com/ovrclk/net/master/mainnet/genesis.json
arno-node-1  | parse error: Invalid numeric literal at line 1, column 6
arno-node-1  | 13:09:36: Starting server
arno-node-1  | 13:09:36: Snapshot will run at 13:12:00 on day 4
arno-node-1  | 1:09PM INF starting node with ABCI Tendermint in-process
```

That was basically because the `snapshot.json` was missing :)

```
arno-node-1  | + '[' -n https://storage.googleapis.com/test-nl-505/rpc.test/snapshot.json ']'
arno-node-1  | ++ curl -s https://storage.googleapis.com/test-nl-505/rpc.test/snapshot.json
arno-node-1  | ++ jq -r .latest
arno-node-1  | parse error: Invalid numeric literal at line 1, column 6
arno-node-1  | + SNAPSHOT_URL=
arno-node-1 exited with code 4
arno-node-1  | + CHAIN_METADATA='{
arno-node-1  |   "chain_name": "akash",
arno-node-1  |   "status": "live",
...
```

