### PR TITLE
snapshot restore: add progress bar, with snapshot size fetched via `Content-Length`

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -35,9 +35,12 @@ export VALIDATE_GENESIS="${VALIDATE_GENESIS:-0}"
 if [[ -n "$BINARY_URL" && ! -f "/bin/$PROJECT_BIN" ]]; then
   echo "Download binary $PROJECT_BIN from $BINARY_URL"
   curl -sLo /bin/$PROJECT_BIN $BINARY_URL
-  file /bin/$PROJECT_BIN | grep -q 'gzip compressed data' && mv /bin/$PROJECT_BIN /bin/$PROJECT_BIN.gz && tar -xvf /bin/$PROJECT_BIN.gz -C /bin
-  file /bin/$PROJECT_BIN | grep -q 'tar archive' && mv /bin/$PROJECT_BIN /bin/$PROJECT_BIN.tar && tar -xf /bin/$PROJECT_BIN.tar && rm /bin/$PROJECT_BIN.tar -C /bin
-  file /bin/$PROJECT_BIN | grep -q 'Zip archive data' && mv /bin/$PROJECT_BIN /bin/$PROJECT_BIN.zip && unzip /bin/$PROJECT_BIN.zip -d /bin
+  file_description=$(file /bin/$PROJECT_BIN)
+  case "${file_description,,}" in
+    *"gzip compressed data"*)   mv /bin/$PROJECT_BIN /bin/$PROJECT_BIN.tgz && tar -xvf /bin/$PROJECT_BIN.tgz -C /bin && rm /bin/$PROJECT_BIN.tgz;;
+    *"tar archive"*)            mv /bin/$PROJECT_BIN /bin/$PROJECT_BIN.tar && tar -xf /bin/$PROJECT_BIN.tar -C /bin && rm /bin/$PROJECT_BIN.tar;;
+    *"zip archive data"*)       mv /bin/$PROJECT_BIN /bin/$PROJECT_BIN.zip && unzip /bin/$PROJECT_BIN.zip -d /bin && rm /bin/$PROJECT_BIN.zip;;
+  esac
   [ -n "$BINARY_ZIP_PATH" ] && mv /bin/${BINARY_ZIP_PATH} /bin
   chmod +x /bin/$PROJECT_BIN
 fi


### PR DESCRIPTION
Update run.sh to support snapshot download progress display

Size value validation part can be tested via
```bash
for snapshot_size_in_bytes in "" "999" "099" "a999" "999a" "a999a" "undefined"; do
  case "$snapshot_size_in_bytes" in
    [1-9]*[0-9]) echo "<$snapshot_size_in_bytes> is integer";;
    *) echo "<$snapshot_size_in_bytes> not integer";;
  esac
done

```

PV code following #262

Test screenshot (with `-i 1` instead)
![Screenshot 2022-08-18 at 16 52 16](https://user-images.githubusercontent.com/1018543/185728002-3c74b55c-8b18-4898-8d91-1cb9e2e3b8e5.png)
