### PR TITLE
Add SNAPSHOT_WASM_PATH support

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Note that snapshots will be restored in-process, without downloading the snapsho
 |`SNAPSHOT_FORMAT`|The format of the snapshot file|`tar.gz`|`tar`/`tar.zst`|
 |`SNAPSHOT_PATTERN`|The pattern of the file in the `SNAPSHOT_BASE_URL`|`$CHAIN_ID.*$SNAPSHOT_FORMAT`|`foobar.*tar.gz`|
 |`SNAPSHOT_DATA_PATH`|The path to the data directory within the archive| |`snapshot/data`|
+|`SNAPSHOT_WASM_PATH`|The path to the wasm directory within the archive, if exists outside of data| |`snapshot/wasm`|
 |`SNAPSHOT_PRUNING`|Type of snapshot to download, e.g. `archive`, `pruned`, `default`.|`pruned`|`archive`|
 |`SNAPSHOT_QUICKSYNC`|A URL to a Quicksync JSON file describing their snapshots. Also see `SNAPSHOT_PRUNING`| |`https://quicksync.io/terra.json`|
 |`SNAPSHOT_POLKACHU`|Import [Polkachu's](https://www.polkachu.com/tendermint_snapshots) snapshot automatically if available| |`1`|

--- a/osmosis/build.yml
+++ b/osmosis/build.yml
@@ -20,6 +20,7 @@ services:
       - P2P_POLKACHU=1
       - STATESYNC_POLKACHU=1
       # - SNAPSHOT_POLKACHU=1
+      # - SNAPSHOT_WASM_PATH=wasm
     env_file:
       - ../.env
     volumes:

--- a/osmosis/deploy.yml
+++ b/osmosis/deploy.yml
@@ -10,6 +10,7 @@ services:
       - P2P_POLKACHU=1
       # - STATESYNC_POLKACHU=1
       - SNAPSHOT_POLKACHU=1
+      - SNAPSHOT_WASM_PATH=wasm
     expose:
       - port: 26657
         as: 80

--- a/osmosis/docker-compose.yml
+++ b/osmosis/docker-compose.yml
@@ -13,5 +13,6 @@ services:
       - P2P_POLKACHU=1
       # - STATESYNC_POLKACHU=1
       - SNAPSHOT_POLKACHU=1
+      - SNAPSHOT_WASM_PATH=wasm
     volumes:
       - ./node-data:/root/.osmosisd

--- a/run.sh
+++ b/run.sh
@@ -279,6 +279,7 @@ if [ "$DOWNLOAD_SNAPSHOT" == "1" ]; then
     (wget -nv -O - $SNAPSHOT_URL | pv -petrafb -i 5 $pv_extra_args | eval $tar_cmd) 2>&1 | stdbuf -o0 tr '\r' '\n'
 
     [ -n "${SNAPSHOT_DATA_PATH}" ] && mv ./${SNAPSHOT_DATA_PATH}/* ./ && rm -rf ./${SNAPSHOT_DATA_PATH}
+    [ -n "${SNAPSHOT_WASM_PATH}" ] && mv ./${SNAPSHOT_WASM_PATH}/* ../wasm && rm -rf ./${SNAPSHOT_WASM_PATH}
   else
     echo "Snapshot URL not found"
   fi

--- a/run.sh
+++ b/run.sh
@@ -279,7 +279,10 @@ if [ "$DOWNLOAD_SNAPSHOT" == "1" ]; then
     (wget -nv -O - $SNAPSHOT_URL | pv -petrafb -i 5 $pv_extra_args | eval $tar_cmd) 2>&1 | stdbuf -o0 tr '\r' '\n'
 
     [ -n "${SNAPSHOT_DATA_PATH}" ] && mv ./${SNAPSHOT_DATA_PATH}/* ./ && rm -rf ./${SNAPSHOT_DATA_PATH}
-    [ -n "${SNAPSHOT_WASM_PATH}" ] && mv ./${SNAPSHOT_WASM_PATH}/* ../wasm && rm -rf ./${SNAPSHOT_WASM_PATH}
+    if [ -n "${SNAPSHOT_WASM_PATH}" ]; then
+      rm -rf ../wasm && mkdir ../wasm
+      mv ./${SNAPSHOT_WASM_PATH}/* ../wasm && rm -rf ./${SNAPSHOT_WASM_PATH}
+    fi
   else
     echo "Snapshot URL not found"
   fi


### PR DESCRIPTION
Handle snapshots containing a wasm directory that exists outside of the `data` directory. Primarily for Osmosis