### PR TITLE
Update Stride to v4.0.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,7 +109,7 @@ jobs:
           - project: stargaze
             version: v7.5.0
           - project: stride
-            version: v4.0.0
+            version: v4.0.2
           - project: starname
             version: v0.11.5
           - project: teritori

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,7 +109,7 @@ jobs:
           - project: stargaze
             version: v7.5.0
           - project: stride
-            version: v3.0.0
+            version: v4.0.0
           - project: starname
             version: v0.11.5
           - project: teritori

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[sommelier](https://github.com/PeggyJV/sommelier)|`v4.0.2`|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.15-sommelier-v4.0.2`|[Example](./sommelier)|
 |[stargaze](https://github.com/public-awesome/stargaze)|`v7.5.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.15-stargaze-v7.5.0`|[Example](./stargaze)|
 |[starname](https://github.com/iov-one/starnamed)|`v0.11.5`|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.15-starname-v0.11.5`|[Example](./starname)|
-|[stride](https://github.com/Stride-Labs/stride)|`v4.0.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.15-stride-v4.0.0`|[Example](./starname)|
+|[stride](https://github.com/Stride-Labs/stride)|`v4.0.2`|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.15-stride-v4.0.2`|[Example](./starname)|
 |[teritori](https://github.com/TERITORI/teritori-chain)|`v1.3.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.15-teritori-v1.3.0`|[Example](./teritori)|
 |[umee](https://github.com/umee-network/umee)|`v3.1.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.15-umee-v3.1.0`|[Example](./umee)|
 |[vidulum](https://github.com/vidulum/mainnet)|`v1.2.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.15-vidulum-v1.2.0`|[Example](./vidulum)|

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[sommelier](https://github.com/PeggyJV/sommelier)|`v4.0.2`|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.15-sommelier-v4.0.2`|[Example](./sommelier)|
 |[stargaze](https://github.com/public-awesome/stargaze)|`v7.5.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.15-stargaze-v7.5.0`|[Example](./stargaze)|
 |[starname](https://github.com/iov-one/starnamed)|`v0.11.5`|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.15-starname-v0.11.5`|[Example](./starname)|
-|[stride](https://github.com/Stride-Labs/stride)|`v3.0.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.15-stride-v3.0.0`|[Example](./starname)|
+|[stride](https://github.com/Stride-Labs/stride)|`v4.0.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.15-stride-v4.0.0`|[Example](./starname)|
 |[teritori](https://github.com/TERITORI/teritori-chain)|`v1.3.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.15-teritori-v1.3.0`|[Example](./teritori)|
 |[umee](https://github.com/umee-network/umee)|`v3.1.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.15-umee-v3.1.0`|[Example](./umee)|
 |[vidulum](https://github.com/vidulum/mainnet)|`v1.2.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.15-vidulum-v1.2.0`|[Example](./vidulum)|

--- a/stride/README.md
+++ b/stride/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v4.0.0`|
+|Version|`v4.0.2`|
 |Binary|`strided`|
 |Directory|`.stride`|
 |ENV namespace|`STRIDED`|
 |Repository|`https://github.com/Stride-Labs/stride`|
-|Image|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.15-stride-v4.0.0`|
+|Image|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.15-stride-v4.0.2`|
 
 ## Examples
 

--- a/stride/README.md
+++ b/stride/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v3.0.0`|
+|Version|`v4.0.0`|
 |Binary|`strided`|
 |Directory|`.stride`|
 |ENV namespace|`STRIDED`|
 |Repository|`https://github.com/Stride-Labs/stride`|
-|Image|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.15-stride-v3.0.0`|
+|Image|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.15-stride-v4.0.0`|
 
 ## Examples
 

--- a/stride/build.yml
+++ b/stride/build.yml
@@ -7,7 +7,7 @@ services:
       args:
         PROJECT: stride
         PROJECT_BIN: strided
-        VERSION: v4.0.0
+        VERSION: v4.0.2
         REPOSITORY: https://github.com/Stride-Labs/stride
         NAMESPACE: STRIDED
         PROJECT_DIR: .stride

--- a/stride/build.yml
+++ b/stride/build.yml
@@ -7,7 +7,7 @@ services:
       args:
         PROJECT: stride
         PROJECT_BIN: strided
-        VERSION: v3.0.0
+        VERSION: v4.0.0
         REPOSITORY: https://github.com/Stride-Labs/stride
         NAMESPACE: STRIDED
         PROJECT_DIR: .stride

--- a/stride/deploy.yml
+++ b/stride/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/ovrclk/cosmos-omnibus:v0.3.15-stride-v4.0.0
+    image: ghcr.io/ovrclk/cosmos-omnibus:v0.3.15-stride-v4.0.2
     env:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/chain.json

--- a/stride/deploy.yml
+++ b/stride/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/ovrclk/cosmos-omnibus:v0.3.15-stride-v3.0.0
+    image: ghcr.io/ovrclk/cosmos-omnibus:v0.3.15-stride-v4.0.0
     env:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/chain.json

--- a/stride/docker-compose.yml
+++ b/stride/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/ovrclk/cosmos-omnibus:v0.3.15-stride-v4.0.0
+    image: ghcr.io/ovrclk/cosmos-omnibus:v0.3.15-stride-v4.0.2
     ports:
       - '26656:26656'
       - '26657:26657'

--- a/stride/docker-compose.yml
+++ b/stride/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/ovrclk/cosmos-omnibus:v0.3.15-stride-v3.0.0
+    image: ghcr.io/ovrclk/cosmos-omnibus:v0.3.15-stride-v4.0.0
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
Pre-release image: `ghcr.io/ovrclk/cosmos-omnibus:v0.3.16-rc1-stride-v4.0.0`
Update block: https://www.mintscan.io/stride/blocks/1365631