### PR TITLE
Updated Quicksync URL & added SNAPSHOT_PRUNING

### DIFF
--- a/cryptoorgchain/build.yml
+++ b/cryptoorgchain/build.yml
@@ -17,7 +17,8 @@ services:
     environment:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/cryptoorgchain/chain.json
-      # - SNAPSHOT_QUICKSYNC=https://quicksync.io/crypto.json
+      # - SNAPSHOT_QUICKSYNC=https://dl2.quicksync.io/json/cronos.json
+      # - SNAPSHOT_PRUNING=leveldb-pruned
     env_file:
       - ../.env
     volumes:

--- a/cryptoorgchain/deploy.yml
+++ b/cryptoorgchain/deploy.yml
@@ -7,7 +7,8 @@ services:
     env:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/cryptoorgchain/chain.json
-      - SNAPSHOT_QUICKSYNC=https://quicksync.io/crypto.json
+      - SNAPSHOT_QUICKSYNC=https://dl2.quicksync.io/json/cronos.json
+      - SNAPSHOT_PRUNING=leveldb-pruned
     expose:
       - port: 26657
         as: 80

--- a/cryptoorgchain/docker-compose.yml
+++ b/cryptoorgchain/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/cryptoorgchain/chain.json
-      - SNAPSHOT_QUICKSYNC=https://quicksync.io/crypto.json
+      - SNAPSHOT_QUICKSYNC=https://dl2.quicksync.io/json/cronos.json
+      - SNAPSHOT_PRUNING=leveldb-pruned
     volumes:
       - ./node-data:/root/.chain-maind


### PR DESCRIPTION
The Quicksync manifest has moved and the curl call in "run.sh" does not follow HTTP302 redirects. 
As a workaround, the new URL is provided.

Additionally, Quicksync offers leveldb and rocksdb snapshots for cryptoorg chain so the default $SNAPSHOT_PRUNING value can not fetch a valid URL. 
Setting SNAPSHOT_PRUNING to "leveldb-pruned" resolves this.