### PR TITLE
Updated quicksync URL & added SNAPSHOT_PRUNING

### DIFF
--- a/cronos/deploy.yml
+++ b/cronos/deploy.yml
@@ -7,6 +7,8 @@ services:
     env:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/cronos/chain.json
+      - SNAPSHOT_QUICKSYNC=https://dl2.quicksync.io/json/cronos.json
+      - SNAPSHOT_PRUNING=leveldb-pruned
     expose:
       - port: 26657
         as: 80

--- a/cronos/docker-compose.yml
+++ b/cronos/docker-compose.yml
@@ -10,5 +10,7 @@ services:
     environment:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/cronos/chain.json
+      - SNAPSHOT_QUICKSYNC=https://dl2.quicksync.io/json/cronos.json
+      - SNAPSHOT_PRUNING=leveldb-pruned
     volumes:
       - ./node-data:/root/.cronos


### PR DESCRIPTION
The Quicksync manifest has moved and the curl call in [run.sh](https://github.com/ovrclk/cosmos-omnibus/blob/ab8fd4875f13a0490fb12ad356a8aa0c235b1fea/run.sh#L252) does not follow HTTP302 redirects. 
As a workaround, the new URL is provided. 

Additionally, Quicksync offers leveldb and rocksdb snapshots for Cronos chain so the default $SNAPSHOT_PRUNING value can not fetch a valid URL. 
Setting SNAPSHOT_PRUNING to "leveldb-pruned" resolves this.