### PR TITLE
Upgrade sifchain to v1.3.0-beta

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -123,7 +123,7 @@ jobs:
           - project: shentu
             version: v2.8.0
           - project: sifchain
-            version: v1.2.0-beta
+            version: v1.3.0-beta
           - project: sommelier
             version: v4.0.2
           - project: stargaze

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[seinetwork](https://github.com/sei-protocol/sei-chain)|`1.2.2beta-postfix`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-seinetwork-1.2.2beta-postfix`|[Example](./seinetwork)|
 |[sentinel](https://github.com/sentinel-official/hub)|`v0.11.3`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-sentinel-v0.11.3`|[Example](./sentinel)|
 |[shentu](https://github.com/certikfoundation/shentu)|`v2.8.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-shentu-v2.8.0`|[Example](./shentu)|
-|[sifchain](https://github.com/Sifchain/sifnode)|`v1.2.0-beta`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-sifchain-v1.2.0-beta`|[Example](./sifchain)|
+|[sifchain](https://github.com/Sifchain/sifnode)|`v1.3.0-beta`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-sifchain-v1.3.0-beta`|[Example](./sifchain)|
 |[sommelier](https://github.com/PeggyJV/sommelier)|`v4.0.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-sommelier-v4.0.2`|[Example](./sommelier)|
 |[stargaze](https://github.com/public-awesome/stargaze)|`v12.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-stargaze-v12.0.0`|[Example](./stargaze)|
 |[starname](https://github.com/iov-one/starnamed)|`v0.11.5`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-starname-v0.11.5`|[Example](./starname)|

--- a/sifchain/README.md
+++ b/sifchain/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v1.2.0-beta`|
+|Version|`v1.3.0-beta`|
 |Binary|`sifnoded`|
 |Directory|`.sifnoded`|
 |ENV namespace|`SIFNODED`|
 |Repository|`https://github.com/Sifchain/sifnode`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-sifchain-v1.2.0-beta`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-sifchain-v1.3.0-beta`|
 
 ## Examples
 

--- a/sifchain/build.yml
+++ b/sifchain/build.yml
@@ -7,7 +7,7 @@ services:
       args:
         PROJECT: sifchain
         PROJECT_BIN: sifnoded
-        VERSION: v1.2.0-beta
+        VERSION: v1.3.0-beta
         REPOSITORY: https://github.com/Sifchain/sifnode.git
     ports:
       - '26656:26656'

--- a/sifchain/deploy.yml
+++ b/sifchain/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.2-sifchain-v1.2.0-beta
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.2-sifchain-v1.3.0-beta
     env:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/sifchain/chain.json

--- a/sifchain/docker-compose.yml
+++ b/sifchain/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.2-sifchain-v1.2.0-beta
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.2-sifchain-v1.3.0-beta
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
Sifchain will be upgraded to v1.3.0-beta at block 15017000

https://ping.pub/sifchain/block/15017000
Estimated Time: 05/12/2023, 04:53:55

Proposal: https://ping.pub/sifchain/gov/146